### PR TITLE
 Fix global variable declaration bug. Add extern key words.

### DIFF
--- a/tolua.h
+++ b/tolua.h
@@ -51,6 +51,6 @@ int  tolua_newint64(lua_State* L);
 void tolua_openuint64(lua_State* L);
 int  tolua_newuint64(lua_State* L);
 
-int toluaflags;
+extern int toluaflags;
 
 #endif


### PR DESCRIPTION
If there is no 'extern' key word, may have duplicate symbol in link phase.